### PR TITLE
test: Tend staging Composio trigger retest (pr.opened)

### DIFF
--- a/staging-trigger-retest.md
+++ b/staging-trigger-retest.md
@@ -1,0 +1,2 @@
+Composio GITHUB_PULL_REQUEST_EVENT trigger retest for Tend staging (wf dba04a6a / ti_X4tYnyn2wm7n).
+Harmless marker; PR can be closed after the run is observed.


### PR DESCRIPTION
Test PR to fire the Composio `GITHUB_PULL_REQUEST_EVENT` trigger for the Tend staging retest
(trigger instance `ti_X4tYnyn2wm7n` → workflow `dba04a6a`, tenant `1befb1a0`).

Harmless single-file marker. Safe to close once the run is observed on staging.
